### PR TITLE
added a special 'pinned' anchor. 

### DIFF
--- a/src/wayland-window.cpp
+++ b/src/wayland-window.cpp
@@ -97,7 +97,7 @@ namespace wf
             parsed_anchor = GTK_LAYER_SHELL_EDGE_RIGHT;
         } else if (anchor.compare("pinned") == 0)
 	{
-	    parsed_anchor = -2;
+	    parsed_anchor = ANCHOR_PINNED_BOTTOM;
 	}
 
         return parsed_anchor;
@@ -113,7 +113,7 @@ namespace wf
         {
             gtk_layer_set_anchor(this->gobj(),
                 (GtkLayerShellEdge)layer_anchor, true);
-        } else if (layer_anchor == -2)
+        } else if (layer_anchor == ANCHOR_PINNED_BOTTOM)
 	{
 	  gtk_layer_set_anchor(this->gobj(),
 			       GTK_LAYER_SHELL_EDGE_BOTTOM, true);

--- a/src/wayland-window.cpp
+++ b/src/wayland-window.cpp
@@ -96,9 +96,9 @@ namespace wf
         {
             parsed_anchor = GTK_LAYER_SHELL_EDGE_RIGHT;
         } else if (anchor.compare("pinned") == 0)
-	{
-	    parsed_anchor = ANCHOR_PINNED_BOTTOM;
-	}
+		{
+			parsed_anchor = ANCHOR_PINNED_BOTTOM;
+		}
 
         return parsed_anchor;
     }

--- a/src/wayland-window.cpp
+++ b/src/wayland-window.cpp
@@ -95,7 +95,10 @@ namespace wf
         } else if (anchor.compare("right") == 0)
         {
             parsed_anchor = GTK_LAYER_SHELL_EDGE_RIGHT;
-        }
+        } else if (anchor.compare("pinned") == 0)
+	{
+	    parsed_anchor = -2;
+	}
 
         return parsed_anchor;
     }
@@ -110,7 +113,17 @@ namespace wf
         {
             gtk_layer_set_anchor(this->gobj(),
                 (GtkLayerShellEdge)layer_anchor, true);
-        }
+        } else if (layer_anchor == -2)
+	{
+	  gtk_layer_set_anchor(this->gobj(),
+			       GTK_LAYER_SHELL_EDGE_BOTTOM, true);
+	  gtk_layer_set_anchor(this->gobj(),
+			       GTK_LAYER_SHELL_EDGE_LEFT, true);
+	  gtk_layer_set_anchor(this->gobj(),
+			       GTK_LAYER_SHELL_EDGE_RIGHT, true);
+	  gtk_layer_auto_exclusive_zone_enable(this->gobj());
+	  
+	}
 
         this->set_size_request(width, height);
         this->show_all();

--- a/src/wayland-window.cpp
+++ b/src/wayland-window.cpp
@@ -96,9 +96,9 @@ namespace wf
         {
             parsed_anchor = GTK_LAYER_SHELL_EDGE_RIGHT;
         } else if (anchor.compare("pinned") == 0)
-	{
-	    parsed_anchor = ANCHOR_PINNED_BOTTOM;
-	}
+        {
+            parsed_anchor = ANCHOR_PINNED_BOTTOM;
+        }
 
         return parsed_anchor;
     }
@@ -114,16 +114,15 @@ namespace wf
             gtk_layer_set_anchor(this->gobj(),
                 (GtkLayerShellEdge)layer_anchor, true);
         } else if (layer_anchor == ANCHOR_PINNED_BOTTOM)
-	{
-	  gtk_layer_set_anchor(this->gobj(),
-			       GTK_LAYER_SHELL_EDGE_BOTTOM, true);
-	  gtk_layer_set_anchor(this->gobj(),
-			       GTK_LAYER_SHELL_EDGE_LEFT, true);
-	  gtk_layer_set_anchor(this->gobj(),
-			       GTK_LAYER_SHELL_EDGE_RIGHT, true);
-	  gtk_layer_auto_exclusive_zone_enable(this->gobj());
-	  
-	}
+        {
+	    gtk_layer_set_anchor(this->gobj(),
+                GTK_LAYER_SHELL_EDGE_BOTTOM, true);
+            gtk_layer_set_anchor(this->gobj(),
+                GTK_LAYER_SHELL_EDGE_LEFT, true);
+            gtk_layer_set_anchor(this->gobj(),
+                GTK_LAYER_SHELL_EDGE_RIGHT, true);
+            gtk_layer_auto_exclusive_zone_enable(this->gobj());
+        }
 
         this->set_size_request(width, height);
         this->show_all();

--- a/src/wayland-window.hpp
+++ b/src/wayland-window.hpp
@@ -10,6 +10,7 @@
 #include <virtual-keyboard-unstable-v1-client-protocol.h>
 
 #define OSK_SPACING 8
+static constexpr int32_t ANCHOR_PINNED_BOTTOM = -2;
 
 namespace wf
 {


### PR DESCRIPTION
Added a special anchor ("pinned") to be able to push windows from below the keyboard and position it at the bottom of the screen.

No special window resize code is needed as the width of the keyboard's window is set automatically by the compositor in exlusive  zone mode. 